### PR TITLE
Update message length handling in SmppClient

### DIFF
--- a/AradSMPP.Net/SmppClient.cs
+++ b/AradSMPP.Net/SmppClient.cs
@@ -1612,10 +1612,12 @@ public class SmppClient : IDisposable
             
         // Standard 160 bytes
         int maxBytes = ShortMessageMaxBytes;
+        int maxLength = ShortMessageMaxBytes;
         if (encodeDataCoding == DataCodings.Ucs2)
         {
             // Unicode message
             maxBytes = 140;
+            maxLength = 70;
         }
 
         // Convert the message to a byte array
@@ -1652,7 +1654,7 @@ public class SmppClient : IDisposable
 
                     // Split the message in parts we can send
                     //List<byte[]> parts = SmppBuffer.SplitMessageOnParts(messageBytes, maxBytes);
-                    var parts = SmppBuffer.Split(message, maxBytes);
+                    var parts = SmppBuffer.Split(message, maxLength);
                     foreach (string part in parts)
                     {
                         SubmitSm? submitSm = SubmitSm.Create(DefaultEncoding, serviceType, srcTon, srcNpi, srcAddr, destTon, destNpi, destAddr);


### PR DESCRIPTION
Introduce maxLength variable for message splitting logic. Adjust UCS2 encoding handling to use maxLength instead of maxBytes.